### PR TITLE
Add notes on VS Code usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,27 +66,6 @@ For the best results, use the following pairs of size / line height:
 
 _You are welcome to add more hints on usage (especially on the desktop) via pull requests._
 
-### In VS Code
-
-To specify values for variable axes, use `editor.fontVariations`:
-
-```jsonc
-// settings.json
-{
-    "editor.fontFamily": "Martian Mono",
-    "editor.fontVariations": "'wdth' 87.5, 'wght' 450",
-}
-```
-
-Consider switching font aliasing method to `auto` for improved rendering on displays with high DPI:
-
-```jsonc
-// settings.json
-{
-    "workbench.fontAliasing": "auto",
-}
-```
-
 ### On the Web
 
 Download the `woff2` package from the [releases page](https://github.com/evilmartians/mono/releases) to get the variable font in WOFF2 format ([see WOFF2 support matrix between browsers](https://caniuse.com/woff2)).
@@ -140,6 +119,27 @@ Open the config file (`~/.config/kitty/kitty.conf`). Look for the `adjust_line_h
 
 ##### VS Code
 
+To specify values for variable axes, use `editor.fontVariations`:
+
+```jsonc
+// settings.json
+{
+    "editor.fontFamily": "Martian Mono",
+    "editor.fontVariations": "'wdth' 87.5, 'wght' 450",
+}
+```
+
+Consider switching font aliasing method to `auto` for improved rendering on displays with high DPI:
+
+```jsonc
+// settings.json
+{
+    "workbench.fontAliasing": "auto",
+}
+```
+
+Finally, fine tune line height (`editor.lineHeight`):
+
 ```jsonc
 // settings.json
 {
@@ -148,7 +148,6 @@ Open the config file (`~/.config/kitty/kitty.conf`). Look for the `adjust_line_h
     "editor.lineHeight": 20,
 }
 ```
-
 
 ##### vim
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ For the best results, use the following pairs of size / line height:
 
 _You are welcome to add more hints on usage (especially on the desktop) via pull requests._
 
+### In VS Code
+
+To specify values for variable axes, use `editor.fontVariations`:
+
+```jsonc
+// settings.json
+{
+    "editor.fontFamily": "Martian Mono",
+    "editor.fontVariations": "'wdth' 87.5, 'wght' 450",
+}
+```
+
+Consider switching font aliasing method to `auto` for improved rendering on displays with high DPI:
+
+```jsonc
+// settings.json
+{
+    "workbench.fontAliasing": "auto",
+}
+```
+
 ### On the Web
 
 Download the `woff2` package from the [releases page](https://github.com/evilmartians/mono/releases) to get the variable font in WOFF2 format ([see WOFF2 support matrix between browsers](https://caniuse.com/woff2)).

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Open the config file (`~/.config/kitty/kitty.conf`). Look for the `adjust_line_h
 
 #### Text editors
 
+##### VS Code
+
+```jsonc
+// settings.json
+{
+    "editor.fontFamily": "Martian Mono",
+    "editor.fontSize": 12.5,
+    "editor.lineHeight": 20,
+}
+```
+
+
 ##### vim
 
 For setting line spacing in GUI versions of vim, see [`linespace`/`lsp`](https://vimhelp.org/options.txt.html#%27linespace%27).


### PR DESCRIPTION
I've noticed some people were struggling to quickly find a ways to specify variable axes in VS Code, so it might be helpful to include an example.

Also added a note on using the `auto` font aliasing method which IMO works better with Martian Mono.